### PR TITLE
Remove free send_buf from ADIOI_LUSTRE_W_Exchange_data

### DIFF
--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -1642,13 +1642,6 @@ static void ADIOI_LUSTRE_W_Exchange_data(
              */
             MEMCPY_UNPACK(myrank, (*send_buf)[my_aggr_idx], start_pos, recv_count, write_buf);
     }
-
-    /* free send_buf[] if allocated */
-    if (*send_buf != NULL) {
-        ADIOI_Free((*send_buf)[0]);
-        ADIOI_Free(*send_buf);
-        *send_buf = NULL;
-    }
 }
 
 

--- a/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
+++ b/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c
@@ -993,7 +993,7 @@ static void ADIOI_LUSTRE_Exch_and_write(ADIO_File fd,
          */
         for (i = 0; i < cb_nodes; i++) {
             if (my_req[i].count) {
-                if (buftype_is_contig)
+                if (buftype_is_contig && send_curr_offlen_ptr[i] < my_req[i].count)
                     this_buf_idx[i] = buf_idx[i][send_curr_offlen_ptr[i]];
                 for (j = send_curr_offlen_ptr[i]; j < my_req[i].count; j++) {
                     if (my_req[i].offsets[j] < iter_end_off)


### PR DESCRIPTION
`MPI_Issend` requires the buffer not modified until the send is completed.

`send_buf` is correctly freed later, inside ADIOI_LUSTRE_Exch_and_write(e.g. [this line](https://github.com/wkliao/mpich/blob/b13ac583806aba0d4ee5dcc20dc6c8a70a56cda6/src/mpi/romio/adio/ad_lustre/ad_lustre_wrcoll.c#L1178)).

----


Without the change, an invalid memory access error can occur using:

- striping size = 1MB
- striping unit = 2
- num_procs = 2
- [FLASH-IO benchmark](https://github.com/Parallel-NetCDF/PnetCDF/tree/master/benchmarks/FLASH-IO), with nxb=nyb=nzb=16, MAXBLOCKS=50

Below is the output from valgrind
```
==3847== Invalid read of size 2
==3847==    at 0x8FCA9E0: memmove (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3847==    by 0xA199E1D: typerep_do_pack.part.0 (in /home/zanhua/mpich/4.1.1/lib/libmpi.so.12.3.0)
==3847==    by 0xA19A114: MPIR_Typerep_pack (in /home/zanhua/mpich/4.1.1/lib/libmpi.so.12.3.0)
==3847==    by 0xA2BA223: MPIDI_POSIX_eager_send (in /home/zanhua/mpich/4.1.1/lib/libmpi.so.12.3.0)
==3847==    by 0xA2667EE: MPIDIG_send_cts_target_msg_cb (in /home/zanhua/mpich/4.1.1/lib/libmpi.so.12.3.0)
==3847==    by 0xA1DF46B: MPIDI_POSIX_progress.constprop.0 (in /home/zanhua/mpich/4.1.1/lib/libmpi.so.12.3.0)
==3847==    by 0xA1E1AB9: MPIDI_progress_test (in /home/zanhua/mpich/4.1.1/lib/libmpi.so.12.3.0)
==3847==    by 0xA1E5E38: MPIR_Waitall_state (in /home/zanhua/mpich/4.1.1/lib/libmpi.so.12.3.0)
==3847==    by 0xA1E6469: MPIR_Waitall (in /home/zanhua/mpich/4.1.1/lib/libmpi.so.12.3.0)
==3847==    by 0x9FB9D67: PMPI_Waitall (in /home/zanhua/mpich/4.1.1/lib/libmpi.so.12.3.0)
==3847==    by 0x8FE3C8E: ADIOI_LUSTRE_Exch_and_write (ad_lustre_wrcoll.c:1172)
==3847==    by 0x8FE20F4: ADIOI_LUSTRE_WriteStridedColl (ad_lustre_wrcoll.c:657)
==3847==  Address 0x12d58424 is 275,428 bytes inside a block of size 1,317,280 free'd
==3847==    at 0x8FC327F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3847==    by 0x901C720: ADIOI_Free_fn (malloc.c:89)
==3847==    by 0x8FE5EE1: ADIOI_LUSTRE_W_Exchange_data (ad_lustre_wrcoll.c:1648)
==3847==    by 0x8FE3612: ADIOI_LUSTRE_Exch_and_write (ad_lustre_wrcoll.c:1032)
==3847==    by 0x8FE20F4: ADIOI_LUSTRE_WriteStridedColl (ad_lustre_wrcoll.c:657)
==3847==    by 0x9031D39: MPIOI_File_write_all (write_all.c:164)
==3847==    by 0x903250E: PMPI_File_write_at_all (write_atall.c:71)
==3847==    by 0x9188604: ncmpio_read_write (in /home/zanhua/pnetcdf/1.12.3/lib/libpnetcdf.so.4.0.3)
==3847==    by 0x9181EB6: wait_getput (in /home/zanhua/pnetcdf/1.12.3/lib/libpnetcdf.so.4.0.3)
==3847==    by 0x918323F: ncmpio_wait (in /home/zanhua/pnetcdf/1.12.3/lib/libpnetcdf.so.4.0.3)
==3847==    by 0x90B7CC0: ncmpi_wait_all (in /home/zanhua/pnetcdf/1.12.3/lib/libpnetcdf.so.4.0.3)
==3847==    by 0x10DCE4: checkpoint_wr_ncmpi_par_ (checkpoint_ncmpi_parallel.F90:606)
==3847==  Block was alloc'd at
==3847==    at 0x8FC0899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3847==    by 0x901C582: ADIOI_Malloc_fn (malloc.c:41)
==3847==    by 0x8FE57F3: ADIOI_LUSTRE_W_Exchange_data (ad_lustre_wrcoll.c:1601)
==3847==    by 0x8FE3612: ADIOI_LUSTRE_Exch_and_write (ad_lustre_wrcoll.c:1032)
==3847==    by 0x8FE20F4: ADIOI_LUSTRE_WriteStridedColl (ad_lustre_wrcoll.c:657)
==3847==    by 0x9031D39: MPIOI_File_write_all (write_all.c:164)
==3847==    by 0x903250E: PMPI_File_write_at_all (write_atall.c:71)
==3847==    by 0x9188604: ncmpio_read_write (in /home/zanhua/pnetcdf/1.12.3/lib/libpnetcdf.so.4.0.3)
==3847==    by 0x9181EB6: wait_getput (in /home/zanhua/pnetcdf/1.12.3/lib/libpnetcdf.so.4.0.3)
==3847==    by 0x918323F: ncmpio_wait (in /home/zanhua/pnetcdf/1.12.3/lib/libpnetcdf.so.4.0.3)
==3847==    by 0x90B7CC0: ncmpi_wait_all (in /home/zanhua/pnetcdf/1.12.3/lib/libpnetcdf.so.4.0.3)
==3847==    by 0x10DCE4: checkpoint_wr_ncmpi_par_ (checkpoint_ncmpi_parallel.F90:606)
==3847==
```
